### PR TITLE
fix: prevent database register warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 export * from './main/index'
 export * from './config/config'
 export const name = 'norn-dice'
+
+export const inject = {
+  required: ['database']
+}


### PR DESCRIPTION
This PR solved the continuous warning of:

```
app Error: property database is not registered, declare it as `inject` to suppress this warning
        at Proxy.<anonymous> (/koishi/node_modules/@snakelet/koishi-plugin-norn-dice/lib/module/coc.js:38:38)
        at Object.apply (/koishi/node_modules/@cordisjs/core/lib/index.cjs:417:23)
        at Proxy.dispatch (/koishi/node_modules/@cordisjs/core/lib/index.cjs:514:27)
        at dispatch.next (<anonymous>)
        at Function.from (<anonymous>)
        at Proxy.emit (/koishi/node_modules/@cordisjs/core/lib/index.cjs:521:11)
        at OneBotBot.dispatch (/koishi/node_modules/@satorijs/core/lib/index.cjs:478:20)
        at dispatchSession (/koishi/node_modules/koishi-plugin-adapter-onebot/lib/index.js:408:7)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Ref: https://koishi.chat/zh-CN/guide/plugin/service.html#inject